### PR TITLE
Flex time per day

### DIFF
--- a/app/src/main/java/org/zephyrsoft/trackworktime/EventEditActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/EventEditActivity.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -49,7 +49,7 @@ import hirondelle.date4j.DateTime.DayOverflow;
 
 /**
  * Activity for managing the events of a week.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class EventEditActivity extends AppCompatActivity implements OnDateChangedListener, OnTimeChangedListener {
@@ -62,6 +62,7 @@ public class EventEditActivity extends AppCompatActivity implements OnDateChange
 	private ArrayAdapter<TypeEnum> typesAdapter;
 	private RadioButton clockIn;
 	private RadioButton clockOut;
+	private RadioButton flexTime;
 	private TextView weekday = null;
 	private DatePicker date = null;
 	private int selectedYear = -1;
@@ -104,6 +105,7 @@ public class EventEditActivity extends AppCompatActivity implements OnDateChange
 		cancel = (Button) findViewById(R.id.cancel);
 		clockIn = (RadioButton) findViewById(R.id.radioClockIn);
 		clockOut = (RadioButton) findViewById(R.id.radioClockOut);
+		flexTime = (RadioButton) findViewById(R.id.radioFlexTime);
 		weekday = (TextView) findViewById(R.id.weekday);
 		date = (DatePicker) findViewById(R.id.date);
 		time = (TimePicker) findViewById(R.id.time);
@@ -131,7 +133,7 @@ public class EventEditActivity extends AppCompatActivity implements OnDateChange
             onTimeChanged(time, time.getCurrentHour(), time.getCurrentMinute());
 
             // save the event
-            TypeEnum typeEnum = clockIn.isChecked() ? TypeEnum.CLOCK_IN : TypeEnum.CLOCK_OUT;
+            TypeEnum typeEnum = clockIn.isChecked() ? TypeEnum.CLOCK_IN : clockOut.isChecked() ? TypeEnum.CLOCK_OUT: TypeEnum.FLEX;
             DateTime dateTime = getCurrentlySetDateAndTime();
             String timeString = DateTimeUtil.dateTimeToString(dateTime);
             Task selectedTask = (Task) task.getSelectedItem();
@@ -218,6 +220,7 @@ public class EventEditActivity extends AppCompatActivity implements OnDateChange
 			newEvent = false;
 			clockIn.setChecked(TypeEnum.CLOCK_IN.getValue().equals(editedEvent.getType()));
 			clockOut.setChecked(TypeEnum.CLOCK_OUT.getValue().equals(editedEvent.getType()));
+			flexTime.setChecked(TypeEnum.FLEX.getValue().equals(editedEvent.getType()));
 			DateTime dateTime = DateTimeUtil.stringToDateTime(editedEvent.getTime());
 			updateDateAndTimePickers(dateTime);
 			for (int i = 0; i < task.getCount(); i++) {

--- a/app/src/main/java/org/zephyrsoft/trackworktime/EventListActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/EventListActivity.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -58,7 +58,7 @@ import hirondelle.date4j.DateTime;
 
 /**
  * Activity for managing the events of a week.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class EventListActivity extends AppCompatActivity {
@@ -333,6 +333,9 @@ public class EventListActivity extends AppCompatActivity {
 				case CLOCK_OUT:
 					typeString = "OUT";
 					break;
+                case FLEX:
+                    typeString = "FLEX";
+                    break;
 				default:
 					throw new IllegalStateException("unrecognized event type");
 			}

--- a/app/src/main/java/org/zephyrsoft/trackworktime/WorkTimeTrackerActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/WorkTimeTrackerActivity.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -80,7 +80,7 @@ import hirondelle.date4j.DateTime;
 
 /**
  * Main activity of the application.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class WorkTimeTrackerActivity extends AppCompatActivity {

--- a/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
@@ -59,6 +59,7 @@ import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK;
 import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK_ID;
 import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK_START;
 import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK_SUM;
+import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK_FLEXI;
 
 /**
  * The data access object for structures from the app's SQLite database. The model consists of three main elements:
@@ -255,13 +256,14 @@ public class DAO {
 
 	// =======================================================
 
-	private static final String[] WEEK_FIELDS = { WEEK_ID, WEEK_START, WEEK_SUM };
+	private static final String[] WEEK_FIELDS = { WEEK_ID, WEEK_START, WEEK_SUM, WEEK_FLEXI };
 
 	private Week cursorToWeek(Cursor cursor) {
 		Week week = new Week();
 		week.setId(cursor.getInt(0));
 		week.setStart(cursor.getString(1));
 		week.setSum(cursor.getInt(2));
+		week.setFlexi(cursor.getInt(3));
 		return week;
 	}
 
@@ -269,6 +271,7 @@ public class DAO {
 		ContentValues ret = new ContentValues();
 		ret.put(WEEK_START, week.getStart());
 		ret.put(WEEK_SUM, week.getSum());
+		ret.put(WEEK_FLEXI, week.getFlexi());
 		return ret;
 	}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -65,7 +65,7 @@ import static org.zephyrsoft.trackworktime.database.MySQLiteHelper.WEEK_SUM;
  * tasks (which are defined by the user and can be referenced when clocking in), events (which are generated when
  * clocking in or out and when changing task or text) and weeks (which are like a clip around events and also can
  * provide a sum so that not all events have to be read to calculate the flexi time).
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class DAO {
@@ -125,7 +125,7 @@ public class DAO {
 
 	/**
 	 * Insert a new task.
-	 * 
+	 *
 	 * @param task
 	 *            the task to add
 	 * @return the newly created task as read from the database (complete with ID)
@@ -142,7 +142,7 @@ public class DAO {
 
 	/**
 	 * Get all tasks.
-	 * 
+	 *
 	 * @return all existing tasks
 	 */
 	public List<Task> getAllTasks() {
@@ -151,7 +151,7 @@ public class DAO {
 
 	/**
 	 * Get all active tasks.
-	 * 
+	 *
 	 * @return all existing tasks that are active at the moment
 	 */
 	public List<Task> getActiveTasks() {
@@ -160,7 +160,7 @@ public class DAO {
 
 	/**
 	 * Get the default task.
-	 * 
+	 *
 	 * @return the default task or {@code null} (if no task was marked as default or if the default task is deactivated)
 	 */
 	public Task getDefaultTask() {
@@ -170,7 +170,7 @@ public class DAO {
 
 	/**
 	 * Get the task with a specific ID.
-	 * 
+	 *
 	 * @param id
 	 *            the ID
 	 * @return the task or {@code null} if the specified ID does not exist
@@ -182,7 +182,7 @@ public class DAO {
 
 	/**
 	 * Get the first task with a specific name.
-	 * 
+	 *
 	 * @param name
 	 *            the name
 	 * @return the task (first if more than one exist) or {@code null} if the specified name does not exist at all
@@ -224,7 +224,7 @@ public class DAO {
 
 	/**
 	 * Update a task.
-	 * 
+	 *
 	 * @param task
 	 *            the task to update - the ID has to be set!
 	 * @return the task as newly read from the database
@@ -241,7 +241,7 @@ public class DAO {
 
 	/**
 	 * Remove a task.
-	 * 
+	 *
 	 * @param task
 	 *            the task to delete - the ID has to be set!
 	 * @return {@code true} if successful, {@code false} if not
@@ -274,7 +274,7 @@ public class DAO {
 
 	/**
 	 * Insert a new week.
-	 * 
+	 *
 	 * @param week
 	 *            the week to add
 	 * @return the newly created week as read from the database (complete with ID)
@@ -301,7 +301,7 @@ public class DAO {
 
 	/**
 	 * Returns the week identified by the given start date or {@code null} if no week exists for that date.
-	 * 
+	 *
 	 * @param start
 	 *            the start date
 	 */
@@ -313,7 +313,7 @@ public class DAO {
 	/**
 	 * Returns all weeks up to the given date. If "start" is a week start date, the week with that start date is also
 	 * included in the result.
-	 * 
+	 *
 	 * @param date
 	 *            the limiting date
 	 */
@@ -324,7 +324,7 @@ public class DAO {
 
 	/**
 	 * Returns the week identified by the given ID or {@code null} if no week exists for that ID.
-	 * 
+	 *
 	 * @param id
 	 *            the ID
 	 */
@@ -349,7 +349,7 @@ public class DAO {
 
 	/**
 	 * Update a week.
-	 * 
+	 *
 	 * @param week
 	 *            the week to update - the ID has to be set!
 	 * @return the week as newly read from the database
@@ -366,7 +366,7 @@ public class DAO {
 
 	/**
 	 * Remove a week.
-	 * 
+	 *
 	 * @param week
 	 *            the week to delete - the ID has to be set!
 	 * @return {@code true} if successful, {@code false} if not
@@ -408,7 +408,7 @@ public class DAO {
 
 	/**
 	 * Insert a new event.
-	 * 
+	 *
 	 * @param event
 	 *            the event to add
 	 * @return the newly created event as read from the database (complete with ID)
@@ -444,7 +444,7 @@ public class DAO {
 
 	/**
 	 * Return all events in a certain week.
-	 * 
+	 *
 	 * @param week
 	 *            the week in which the events are searched - the ID has to be set!
 	 */
@@ -458,7 +458,7 @@ public class DAO {
 
 	/**
 	 * Return all events on a certain day.
-	 * 
+	 *
 	 * @param day
 	 *            the day on which the events are searched
 	 */
@@ -468,7 +468,7 @@ public class DAO {
 
 	/**
 	 * Fetch a specific event.
-	 * 
+	 *
 	 * @param id
 	 *            the ID of the event
 	 * @return the event, or {@code null} if the id does not exist
@@ -481,7 +481,7 @@ public class DAO {
 
 	/**
 	 * Return the last event before a certain date and time or {@code null} if there is no such event.
-	 * 
+	 *
 	 * @param dateTime
 	 *            the date and time before which the event is searched
 	 */
@@ -495,7 +495,7 @@ public class DAO {
 	/**
 	 * Return the last event before a certain date and time (including the hour and minute given!) or {@code null} if
 	 * there is no such event.
-	 * 
+	 *
 	 * @param dateTime
 	 *            the date and time before which the event is searched
 	 */
@@ -508,7 +508,7 @@ public class DAO {
 
 	/**
 	 * Return the first event after a certain date and time or {@code null} if there is no such event.
-	 * 
+	 *
 	 * @param dateTime
 	 *            the date and time after which the event is searched
 	 */
@@ -551,7 +551,7 @@ public class DAO {
 
 	/**
 	 * Update an event.
-	 * 
+	 *
 	 * @param event
 	 *            the event to update - the ID has to be set!
 	 * @return the event as newly read from the database
@@ -568,7 +568,7 @@ public class DAO {
 
 	/**
 	 * Remove an event.
-	 * 
+	 *
 	 * @param event
 	 *            the event to delete - the ID has to be set!
 	 * @return {@code true} if successful, {@code false} if not
@@ -727,6 +727,8 @@ public class DAO {
 		// cache values
 		final String clockInReadableName = TypeEnum.CLOCK_IN.getReadableName();
 		final String clockOutNowReadableName = TypeEnum.CLOCK_OUT_NOW.getReadableName();
+		final String clockOutReadableName = TypeEnum.CLOCK_OUT.getReadableName();
+		final String flexTimeReadableName = TypeEnum.FLEX.getReadableName();
 		while ((line = reader.readLine()) != null) {
 			buffer.append(line).append(eol);
 			final String[] columns = line.split("[;\t]");
@@ -754,9 +756,14 @@ public class DAO {
 						typeEnum = TypeEnum.CLOCK_IN;
 					} else if (clockOutNowReadableName.equalsIgnoreCase(columns[INDEX_EVENT_TYPE])) {
 						typeEnum = TypeEnum.CLOCK_OUT_NOW;
-					} else {
+					} else if (clockOutReadableName.equalsIgnoreCase(columns[INDEX_EVENT_TYPE])) {
 						typeEnum = TypeEnum.CLOCK_OUT;
-					}
+					} else if (flexTimeReadableName.equalsIgnoreCase(columns[INDEX_EVENT_TYPE])) {
+						typeEnum = TypeEnum.FLEX;
+                    } else {
+                        // this type is not known, so we skip this entry
+                        continue;
+                    }
 					timerManager.createEvent(dateTime,
 						Integer.parseInt(columns[INDEX_EVENT_TASK]),
 						typeEnum,

--- a/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/database/DAO.java
@@ -263,7 +263,9 @@ public class DAO {
 		week.setId(cursor.getInt(0));
 		week.setStart(cursor.getString(1));
 		week.setSum(cursor.getInt(2));
-		week.setFlexi(cursor.getInt(3));
+		if (!cursor.isNull(3)) {
+			week.setFlexi(cursor.getInt(3));
+		}
 		return week;
 	}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/database/MySQLiteHelper.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/database/MySQLiteHelper.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,13 +24,13 @@ import org.pmw.tinylog.Logger;
 
 /**
  * Helper class to manage the SQLite database.
- * 
+ *
  * Database version history:
- * 
+ *
  * 1: used only in development.
  * 2: initial layout, since 0.5.0.
  * 3: added column "default" in task table, since 0.5.12.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 @SuppressWarnings("SyntaxError")
@@ -57,6 +57,8 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 	public static final String WEEK_START = "start";
 	/** name of the sum attribute of the week table - in whole minutes */
 	public static final String WEEK_SUM = "sum";
+	/** name of the flexi attribute of the week table - in whole minutes */
+	public static final String WEEK_FLEXI = "flexi";
 
 	/** name of the event table */
 	public static final String EVENT = "event";
@@ -80,7 +82,7 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 		+ " integer primary key autoincrement, " + TASK_NAME + " text not null, " + TASK_ACTIVE + " integer not null, "
 		+ TASK_ORDERING + " integer null);";
 	private static final String DATABASE_CREATE_WEEK = "create table " + WEEK + " (" + WEEK_ID
-		+ " integer primary key autoincrement, " + WEEK_START + " text not null, " + WEEK_SUM + " integer null);";
+		+ " integer primary key autoincrement, " + WEEK_START + " text not null, " + WEEK_SUM + " integer null, " + WEEK_FLEXI +" integer null);";
 	private static final String DATABASE_CREATE_EVENT = "create table " + EVENT + " (" + EVENT_ID
 		+ " integer primary key autoincrement, " + EVENT_WEEK + " integer null, " + EVENT_TYPE + " integer not null, "
 		+ EVENT_TIME + " text not null, " + EVENT_TASK + " integer null, " + EVENT_TEXT + " text null);";
@@ -121,6 +123,7 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 			dbUpgradeFrom2to3(database);
 			currentVersion++;
 		}
+        // TODO upgrade from 3 to 4 and add week.flexi (int) column
 		if (currentVersion != newVersion) {
 			throw new IllegalStateException("could not upgrade database");
 		}

--- a/app/src/main/java/org/zephyrsoft/trackworktime/database/MySQLiteHelper.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/database/MySQLiteHelper.java
@@ -76,7 +76,7 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 	public static final String EVENT_TEXT = "customtext";
 
 	static final String DATABASE_NAME = "trackworktime.db";
-	private static final int DATABASE_VERSION = 3;
+	private static final int DATABASE_VERSION = 4;
 
 	private static final String DATABASE_CREATE_TASK = "create table " + TASK + " (" + TASK_ID
 		+ " integer primary key autoincrement, " + TASK_NAME + " text not null, " + TASK_ACTIVE + " integer not null, "
@@ -94,6 +94,9 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 		+ " add column " + TASK_DEFAULT + " integer not null default 0;";
 	private static final String DATABASE_UPDATE_TASK_2_TO_3 = "update " + TASK
 		+ " set " + TASK_DEFAULT + "=1 where " + TASK_NAME + "='Default';";
+
+	private static final String DATABASE_ALTER_WEEK_3_TO_4 = "alter table " + WEEK
+		+ " add column " + WEEK_FLEXI + " integer null;";
 
 	/**
 	 * Constructor
@@ -123,7 +126,10 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 			dbUpgradeFrom2to3(database);
 			currentVersion++;
 		}
-        // TODO upgrade from 3 to 4 and add week.flexi (int) column
+		if (currentVersion == 3) {
+			dbUpgradeFrom3to4(database);
+			currentVersion++;
+		}
 		if (currentVersion != newVersion) {
 			throw new IllegalStateException("could not upgrade database");
 		}
@@ -141,6 +147,10 @@ public class MySQLiteHelper extends SQLiteOpenHelper {
 		database.execSQL(DATABASE_ALTER_TASK_2_TO_3);
 		// make 'Default' task "really default"
 		database.execSQL(DATABASE_UPDATE_TASK_2_TO_3);
+	}
+
+	private void dbUpgradeFrom3to4(SQLiteDatabase database) {
+		database.execSQL(DATABASE_ALTER_WEEK_3_TO_4);
 	}
 
 }

--- a/app/src/main/java/org/zephyrsoft/trackworktime/model/TypeEnum.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/model/TypeEnum.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,7 @@ import java.util.List;
 
 /**
  * The possible event types - clock in or clock out.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public enum TypeEnum {
@@ -38,7 +38,11 @@ public enum TypeEnum {
 	 * clock-out now type of event used to display correct amount of worked time on current day when currently clocked
 	 * in - THIS TYPE NEVER COMES FROM THE DATABASE
 	 */
-	CLOCK_OUT_NOW(Values.CLOCK_OUT_NOW_VALUE, "out (current time)");
+	CLOCK_OUT_NOW(Values.CLOCK_OUT_NOW_VALUE, "out (current time)"),
+    /**
+     * flex type defines a individual flex time for this day
+     */
+    FLEX(Values.FLEX_VALUE, "flex");
 
 	private Integer value = null;
 	private String readableName = null;
@@ -74,7 +78,7 @@ public enum TypeEnum {
 
 	/**
 	 * Get the enum for a specific value.
-	 * 
+	 *
 	 * @param value
 	 *            the value
 	 * @return the corresponding enum
@@ -88,6 +92,8 @@ public enum TypeEnum {
 			return CLOCK_OUT;
 		} else if (value == Values.CLOCK_OUT_NOW_VALUE) {
 			return CLOCK_OUT_NOW;
+        } else if (value == Values.FLEX_VALUE) {
+            return FLEX;
 		} else {
 			throw new IllegalArgumentException("unknown value");
 		}
@@ -96,6 +102,7 @@ public enum TypeEnum {
 	private static class Values {
 		private static final int CLOCK_IN_VALUE = 1;
 		private static final int CLOCK_OUT_VALUE = 0;
+		private static final int FLEX_VALUE = 2;
 		private static final int CLOCK_OUT_NOW_VALUE = -1;
 	}
 }

--- a/app/src/main/java/org/zephyrsoft/trackworktime/model/Week.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/model/Week.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,7 +20,7 @@ import org.zephyrsoft.trackworktime.database.DAO;
 
 /**
  * Data class for a week.
- * 
+ *
  * @see DAO
  * @author Mathis Dirksen-Thedens
  */
@@ -29,15 +29,17 @@ public class Week extends Base implements Comparable<Week> {
 	private String start = null;
 	/** amount of minutes worked in this week */
 	private Integer sum = null;
+	private Integer flexi = null;
 
 	public Week() {
 		// do nothing
 	}
 
-	public Week(Integer id, String start, Integer sum) {
+	public Week(Integer id, String start, Integer sum, Integer flexi) {
 		this.id = id;
 		this.start = start;
 		this.sum = sum;
+		this.flexi = flexi;
 	}
 
 	public Integer getId() {
@@ -50,6 +52,10 @@ public class Week extends Base implements Comparable<Week> {
 
 	public Integer getSum() {
 		return sum;
+	}
+
+	public Integer getFlexi() {
+		return flexi;
 	}
 
 	public void setId(Integer id) {
@@ -67,6 +73,10 @@ public class Week extends Base implements Comparable<Week> {
 		this.sum = sum;
 	}
 
+	public void setFlexi(Integer flexi) {
+		this.flexi = flexi;
+	}
+
 	@Override
 	public int compareTo(Week another) {
 		return compare(getStart(), another.getStart(), compare(getId(), another.getId(), 0));
@@ -74,7 +84,7 @@ public class Week extends Base implements Comparable<Week> {
 
 	/**
 	 * This is used e.g. by an ArrayAdapter in a ListView and it is also useful for debugging.
-	 * 
+	 *
 	 * @see org.zephyrsoft.trackworktime.model.Base#toString()
 	 */
 	@Override

--- a/app/src/main/java/org/zephyrsoft/trackworktime/model/WeekPlaceholder.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/model/WeekPlaceholder.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,7 +18,7 @@ package org.zephyrsoft.trackworktime.model;
 
 /**
  * Placeholder for a week which does not (yet) need to be persisted, probably because no event exists for this week.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class WeekPlaceholder extends Week {
@@ -27,7 +27,7 @@ public class WeekPlaceholder extends Week {
 	 * Constructor
 	 */
 	public WeekPlaceholder(String start) {
-		super(null, start, null);
+		super(null, start, null, null);
 	}
 
 	@Override
@@ -46,7 +46,17 @@ public class WeekPlaceholder extends Week {
 	}
 
 	@Override
+	public Integer getFlexi() {
+		return 0;
+	}
+
+	@Override
 	public void setSum(Integer sum) {
+		throw new IllegalStateException("operation not permitted for a week placeholder");
+	}
+
+	@Override
+	public void setFlexi(Integer flexi) {
 		throw new IllegalStateException("operation not permitted for a week placeholder");
 	}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
@@ -120,12 +120,12 @@ public class TimeCalculator {
 	public DayLine calulateOneDay(DateTime day, List<Event> eventsOfOneDay) {
 		DayLine ret = new DayLine();
 
-        boolean found_day_flex_time = false;
+        boolean foundDayFlexTime = false;
         for (Event event : eventsOfOneDay) {
             if (event.getType() == TypeEnum.FLEX.getValue()) {
-                DateTime flex_time = DateTimeUtil.stringToDateTime(event.getTime());
-                ret.getTimeFlexi().substract(flex_time.getHour(), flex_time.getMinute());
-                found_day_flex_time = true;
+                DateTime flexTime = DateTimeUtil.stringToDateTime(event.getTime());
+                ret.getTimeFlexi().substract(flexTime.getHour(), flexTime.getMinute());
+                foundDayFlexTime = true;
                 break;
             }
         }
@@ -133,13 +133,13 @@ public class TimeCalculator {
         // get default flex time from settings
 		WeekDayEnum weekDay = WeekDayEnum.getByValue(day.getWeekDay());
 		if (Basics.getInstance().getPreferences().getBoolean(Key.ENABLE_FLEXI_TIME.getName(), false)
-			&& timerManager.isWorkDay(weekDay) && found_day_flex_time == false) {
+			&& timerManager.isWorkDay(weekDay) && foundDayFlexTime == false) {
 			// substract the "normal" work time for one day
 			int normalWorkTimeInMinutes = timerManager.getNormalWorkDurationFor(weekDay);
 			ret.getTimeFlexi().substract(0, normalWorkTimeInMinutes);
 		}
 
-		if (eventsOfOneDay == null || eventsOfOneDay.isEmpty() || found_day_flex_time && eventsOfOneDay.size() == 1) {
+		if (eventsOfOneDay == null || eventsOfOneDay.isEmpty() || foundDayFlexTime && eventsOfOneDay.size() == 1) {
 			return ret;
 		}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
@@ -1,16 +1,16 @@
 /*
  * This file is part of TrackWorkTime (TWT).
- * 
+ *
  * TWT is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * TWT is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,6 +25,7 @@ import org.zephyrsoft.trackworktime.model.PeriodEnum;
 import org.zephyrsoft.trackworktime.model.Range;
 import org.zephyrsoft.trackworktime.model.Task;
 import org.zephyrsoft.trackworktime.model.TimeSum;
+import org.zephyrsoft.trackworktime.model.TypeEnum;
 import org.zephyrsoft.trackworktime.model.Unit;
 import org.zephyrsoft.trackworktime.model.WeekDayEnum;
 import org.zephyrsoft.trackworktime.options.Key;
@@ -40,7 +41,7 @@ import hirondelle.date4j.DateTime.DayOverflow;
 
 /**
  * Calculates the actual work times from events.
- * 
+ *
  * @author Mathis Dirksen-Thedens
  */
 public class TimeCalculator {
@@ -119,15 +120,26 @@ public class TimeCalculator {
 	public DayLine calulateOneDay(DateTime day, List<Event> eventsOfOneDay) {
 		DayLine ret = new DayLine();
 
+        boolean found_day_flex_time = false;
+        for (Event event : eventsOfOneDay) {
+            if (event.getType() == TypeEnum.FLEX.getValue()) {
+                DateTime flex_time = DateTimeUtil.stringToDateTime(event.getTime());
+                ret.getTimeFlexi().substract(flex_time.getHour(), flex_time.getMinute());
+                found_day_flex_time = true;
+                break;
+            }
+        }
+
+        // get default flex time from settings
 		WeekDayEnum weekDay = WeekDayEnum.getByValue(day.getWeekDay());
 		if (Basics.getInstance().getPreferences().getBoolean(Key.ENABLE_FLEXI_TIME.getName(), false)
-			&& timerManager.isWorkDay(weekDay)) {
+			&& timerManager.isWorkDay(weekDay) && found_day_flex_time == false) {
 			// substract the "normal" work time for one day
 			int normalWorkTimeInMinutes = timerManager.getNormalWorkDurationFor(weekDay);
 			ret.getTimeFlexi().substract(0, normalWorkTimeInMinutes);
 		}
 
-		if (eventsOfOneDay == null || eventsOfOneDay.isEmpty()) {
+		if (eventsOfOneDay == null || eventsOfOneDay.isEmpty() || found_day_flex_time && eventsOfOneDay.size() == 1) {
 			return ret;
 		}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
@@ -344,7 +344,7 @@ public class TimerManager {
 				ret.add(eventTime.getHour(), eventTime.getMinute());
 				Logger.debug("calculating flexi time for {} {} event found: {}", day.toString(), weekDay.getValue(), flex_time.toString());
 				found_flex_time = true;
-				break;  // there can only be one flext time per day
+				break;  // there can only be one flexi time per day
 			}
 			if (found_flex_time == false) {
 				int normalWorkTimeInMinutes = getNormalWorkDurationFor(weekDay);

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
@@ -450,8 +450,7 @@ public class TimerManager {
 			Integer weekFlexiMinutes = week.getFlexi();
 			if (weekFlexiMinutes != null) {
 				ret.substract(0, weekFlexiMinutes);
-			}
-			else {
+			} else {
 				ret.substract(0, targetWorkTime.getAsMinutes());
 				Logger.warn("week {} (starting at {}) has a null flexi sum using default {}", week.getId(),
 					week.getStart(), targetWorkTimeString);

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimerManager.java
@@ -331,7 +331,7 @@ public class TimerManager {
 		for (WeekDayEnum weekDay : WeekDayEnum.values()) {
 			DateTime day = date.plusDays(weekDay.getValue() - 1);
 			events = dao.getEventsOnDay(day);
-			boolean found_flex_time = false;
+			boolean foundFlexTime = false;
 			for (Event event : events) {
 				DateTime eventTime = DateTimeUtil.stringToDateTime(event.getTime());
 
@@ -340,13 +340,13 @@ public class TimerManager {
 					continue;
 				}
 
-				DateTime flex_time = DateTimeUtil.stringToDateTime(event.getTime());
+				DateTime flexTime = DateTimeUtil.stringToDateTime(event.getTime());
 				ret.add(eventTime.getHour(), eventTime.getMinute());
-				Logger.debug("calculating flexi time for {} {} event found: {}", day.toString(), weekDay.getValue(), flex_time.toString());
-				found_flex_time = true;
-				break;  // there can only be one flexi time per day
+				Logger.debug("calculating flexi time for {} {} event found: {}", day.toString(), weekDay.getValue(), flexTime.toString());
+				foundFlexTime = true;
+				break;  // there can only be one flext time per day
 			}
-			if (found_flex_time == false) {
+			if (foundFlexTime == false) {
 				int normalWorkTimeInMinutes = getNormalWorkDurationFor(weekDay);
 				ret.add(0, normalWorkTimeInMinutes);
 				Logger.debug("calculating flexi time for {} {} no event found, use default: {}", day.toString(), weekDay.getValue(), normalWorkTimeInMinutes);
@@ -659,10 +659,10 @@ public class TimerManager {
 			weekToUse.setSum(0);
 		}
 
-		TimeSum flexi_sum = calculateFlexTimeSum(DateTimeUtil.stringToDateTime(week.getStart()));
-		int flexi_minutes = flexi_sum.getAsMinutes();
-		Logger.info("updating the flexi time sum to {} minutes for the week beginning at {}", flexi_minutes, week.getStart());
-		weekToUse.setFlexi(flexi_minutes);
+		TimeSum flexiSum = calculateFlexTimeSum(DateTimeUtil.stringToDateTime(week.getStart()));
+		int flexiMinutes = flexiSum.getAsMinutes();
+		Logger.info("updating the flexi time sum to {} minutes for the week beginning at {}", flexiMinutes, week.getStart());
+		weekToUse.setFlexi(flexiMinutes);
 
 		dao.updateWeek(weekToUse);
 		// TODO update the sum of the last week(s) if type is CLOCK_OUT?

--- a/app/src/main/res/layout/event.xml
+++ b/app/src/main/res/layout/event.xml
@@ -52,15 +52,15 @@
 		        android:layout_width="wrap_content"
 		        android:layout_height="wrap_content"
 		        android:orientation="horizontal" >
-		 
+
 		        <RadioButton
 		            android:id="@+id/radioClockIn"
 		            android:layout_width="wrap_content"
 		            android:layout_height="wrap_content"
 		            android:layout_weight="1"
-		            android:text="@string/clockIn" 
+		            android:text="@string/clockIn"
 		            android:checked="true" />
-		 
+
 		        <RadioButton
 		            android:id="@+id/radioClockOut"
 		            android:layout_width="wrap_content"
@@ -68,8 +68,16 @@
 		            android:layout_marginLeft="5dp"
 		            android:layout_weight="1"
 		            android:text="@string/clockOut" />
+
+		        <RadioButton
+		            android:id="@+id/radioFlexTime"
+		            android:layout_width="wrap_content"
+		            android:layout_height="wrap_content"
+		            android:layout_marginLeft="5dp"
+		            android:layout_weight="1"
+		            android:text="@string/flexTime" />
 		    </RadioGroup>
-			
+
             <TextView
                 android:id="@+id/dateTimeLabel"
                 android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_name">Track Work Time</string>
     <string name="yes">Yes</string>
-    <string name="no">No</string> 
+    <string name="no">No</string>
     <string name="website">https://zephyrsoft.org</string>
     <string name="email">android@zephyrsoft.org</string>
     <string name="in">IN</string>
@@ -35,6 +35,7 @@
     <string name="clockInChangeShort">New Period</string>
     <string name="clockOut">Stop Tracking</string>
     <string name="clockOutShort">Stop</string>
+    <string name="flexTime">Flex Time</string>
     <string name="insert_default_times">Multi-Insert</string>
     <string name="edit_tasks">Edit Tasks</string>
     <string name="edit_events">Edit Events</string>


### PR DESCRIPTION
This PR fixes #47 'weekly/daily flexi time'

- Added a new event type called 'FLEX' which overrides the default FLEX-Time for this day.
- FLEX-Time is saved for each week in the database, so if the default flex time is changed over the time, the old weeks keep their flex time (until you re import the data)

My editor removed all trailing white spaces, sorry for theses many changes. Since I'm not a Java programmer I'm not sure if theses spaces where intentional. If you want to keep them let me know.