### PR TITLE
Fixed main screen text alignment

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -82,8 +82,6 @@
                 android:id="@+id/taskLabel"
                 android:layout_width="50dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginBottom="3dp"
                 android:text="@string/task"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -104,8 +102,6 @@
                 android:id="@+id/textLabel"
                 android:layout_width="50dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginBottom="3dp"
                 android:text="@string/text"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 


### PR DESCRIPTION
Fixed alignment between TextView and Spinner, for task selection.
Fixed alignment between TextView and EditText, for optional text.

Text views are by default baseline aligned. In this case, setting TextView gravity to center_vertical, broke this alignment.

Left: With this fix. Right: Current master.
![image](https://user-images.githubusercontent.com/5972966/67641464-99f91700-f902-11e9-995c-853b32d5f003.png)
