### PR TITLE
Changed storage dir to point to common place

### DIFF
--- a/app/src/main/java/org/zephyrsoft/trackworktime/ExternalStorage.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/ExternalStorage.java
@@ -39,7 +39,7 @@ public class ExternalStorage {
 			Logger.error("external storage {} is not writable", externalStorageDirectory);
 			return null;
 		}
-		File twtDirectory = new File(externalStorageDirectory, "trackworktime");
+		File twtDirectory = new File(externalStorageDirectory, Constants.DATA_DIR);
 		if (!twtDirectory.isDirectory() && !twtDirectory.mkdirs()) {
 			Logger.error("directory {} could not be created", twtDirectory);
 			return null;


### PR DESCRIPTION
I guess this should be like this, since it's used like this of few other places.

Tough I think `Constants.DATA_DIR` should also include path from `Environment.getExternalStorageDirectory()`.