### PR TITLE
Fixed unrelated wifi service stopping

### DIFF
--- a/app/src/main/java/org/zephyrsoft/trackworktime/Basics.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/Basics.java
@@ -384,7 +384,7 @@ public class Basics extends BroadcastReceiver {
 				startLocationTrackerService(latitude, longitude, tolerance, vibrate);
 			} else {
 				// just in case
-				stopWifiTrackerService();
+				stopLocationTrackerService();
 			}
 		} else {
 			stopLocationTrackerService();


### PR DESCRIPTION
This doesn't seem right. When location-service settings are incorrect, wifi-service is stopped?