### PR TITLE
Hotfix for 1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
     buildTypes {
         release {
             postprocessing {
-                removeUnusedCode true
+                removeUnusedCode false
                 obfuscate false
                 optimizeCode false
             }

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorV2.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorV2.java
@@ -159,7 +159,7 @@ public class TimeCalculatorV2 {
 				dao.getLastEventBefore(this.currentDate.atStartOfDay(zoneId).toOffsetDateTime());
 
 		// get next flexi reset
-		if (flexiReset != FlexiReset.NONE) {
+		if (flexiReset != null && flexiReset != FlexiReset.NONE) {
 			nextFlexiReset = flexiReset.getNextResetDate(currentDate);
 		}
 	}


### PR DESCRIPTION
The problem with the time calculator was an obvious error, that I introduced in revision 3221c91. Sorry for that.
The SuperCsvReflectionException may be caused by removeUnusedCode if this removes the seemingly unused getters in the event class in release mode. This is a guess, but it is the only place I touched the related code / logic.