### PR TITLE
Change edit event date selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,7 +92,7 @@
             android:label="@string/edit_events" >
         </activity>
         <activity
-            android:name="EventEditActivity"
+            android:name=".editevent.EventEditActivity"
             android:exported="false"
             android:label="@string/edit_event" >
         </activity>

--- a/app/src/main/java/org/zephyrsoft/trackworktime/EventListActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/EventListActivity.java
@@ -44,6 +44,7 @@ import org.zephyrsoft.trackworktime.database.DAO;
 import org.zephyrsoft.trackworktime.databinding.ListActivityBinding;
 import org.zephyrsoft.trackworktime.databinding.ListItemBinding;
 import org.zephyrsoft.trackworktime.databinding.ListItemSeparatorBinding;
+import org.zephyrsoft.trackworktime.editevent.EventEditActivity;
 import org.zephyrsoft.trackworktime.model.Event;
 import org.zephyrsoft.trackworktime.model.EventSeparator;
 import org.zephyrsoft.trackworktime.model.Week;

--- a/app/src/main/java/org/zephyrsoft/trackworktime/editevent/DateTextViewController.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/editevent/DateTextViewController.java
@@ -8,7 +8,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.threeten.bp.LocalDate;
+import org.threeten.bp.ZonedDateTime;
 import org.zephyrsoft.trackworktime.util.DateTimeUtil;
+
+import static org.zephyrsoft.trackworktime.util.DateTimeUtil.dateToEpoch;
 
 class DateTextViewController {
 
@@ -16,6 +19,12 @@ class DateTextViewController {
 
 	@Nullable
 	private LocalDate date;
+
+	@Nullable
+	private ZonedDateTime min;
+
+	@Nullable
+	private ZonedDateTime max;
 
 	DateTextViewController(@NonNull TextView view) {
 		this.view = view;
@@ -31,6 +40,7 @@ class DateTextViewController {
 				date.getMonthValue() - 1,
 				date.getDayOfMonth()
 		);
+		setDateLimits(dialog);
 		dialog.show();
 	}
 
@@ -47,6 +57,16 @@ class DateTextViewController {
 		setDate(newDate);
 	}
 
+	private void setDateLimits(DatePickerDialog dialog) {
+		DatePicker picker = dialog.getDatePicker();
+		if (min != null) {
+			picker.setMinDate(dateToEpoch(min));
+		}
+		if (max != null) {
+			picker.setMaxDate(dateToEpoch(max));
+		}
+	}
+
 	public void setDate(LocalDate date) {
 		String text = DateTimeUtil.formatLocalizedDateShort(date);
 		view.setText(text);
@@ -56,6 +76,14 @@ class DateTextViewController {
 	@Nullable
 	public LocalDate getDate() {
 		return date;
+	}
+
+	public void setDateLimits(
+			@Nullable ZonedDateTime minInclusive,
+			@Nullable ZonedDateTime maxInclusive
+	) {
+		min = minInclusive;
+		max = maxInclusive;
 	}
 
 }

--- a/app/src/main/java/org/zephyrsoft/trackworktime/editevent/DateTextViewController.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/editevent/DateTextViewController.java
@@ -1,0 +1,61 @@
+package org.zephyrsoft.trackworktime.editevent;
+
+import android.app.DatePickerDialog;
+import android.widget.DatePicker;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.threeten.bp.LocalDate;
+import org.zephyrsoft.trackworktime.util.DateTimeUtil;
+
+class DateTextViewController {
+
+	private final TextView view;
+
+	@Nullable
+	private LocalDate date;
+
+	DateTextViewController(@NonNull TextView view) {
+		this.view = view;
+		view.setOnClickListener(v -> showDatePicker());
+	}
+
+	private void showDatePicker() {
+		LocalDate date = getInitialPickerDate();
+		DatePickerDialog dialog = new DatePickerDialog(
+				view.getContext(),
+				this::onNewDateSelected,
+				date.getYear(),
+				date.getMonthValue() - 1,
+				date.getDayOfMonth()
+		);
+		dialog.show();
+	}
+
+	private LocalDate getInitialPickerDate() {
+		if (date == null) {
+			return LocalDate.now();
+	 	} else {
+			return date;
+		}
+	}
+
+	private void onNewDateSelected(DatePicker picker, int year, int month, int day) {
+		LocalDate newDate = LocalDate.of(year, month + 1, day);
+		setDate(newDate);
+	}
+
+	public void setDate(LocalDate date) {
+		String text = DateTimeUtil.formatLocalizedDateShort(date);
+		view.setText(text);
+		this.date = date;
+	}
+
+	@Nullable
+	public LocalDate getDate() {
+		return date;
+	}
+
+}

--- a/app/src/main/java/org/zephyrsoft/trackworktime/editevent/EventEditActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/editevent/EventEditActivity.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License 3.0
  * along with TWT. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.zephyrsoft.trackworktime;
+package org.zephyrsoft.trackworktime.editevent;
 
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
@@ -32,6 +32,10 @@ import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.ZonedDateTime;
+import org.zephyrsoft.trackworktime.Basics;
+import org.zephyrsoft.trackworktime.Constants;
+import org.zephyrsoft.trackworktime.EventListActivity;
+import org.zephyrsoft.trackworktime.R;
 import org.zephyrsoft.trackworktime.database.DAO;
 import org.zephyrsoft.trackworktime.databinding.EventBinding;
 import org.zephyrsoft.trackworktime.model.Event;

--- a/app/src/main/java/org/zephyrsoft/trackworktime/editevent/EventEditActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/editevent/EventEditActivity.java
@@ -28,6 +28,7 @@ import org.pmw.tinylog.Logger;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
 import org.zephyrsoft.trackworktime.Basics;
 import org.zephyrsoft.trackworktime.Constants;
@@ -231,6 +232,16 @@ public class EventEditActivity extends AppCompatActivity implements OnTimeChange
 
 	private void updateDatePicker(LocalDate date) {
 		dateTextViewController.setDate(date);
+
+		if (pickersAreInitialized) {
+			return;
+		}
+
+		ZoneId zone = getSelectedZone();
+		dateTextViewController.setDateLimits(
+				week.getStart().atStartOfDay(zone),
+				week.getEnd().atStartOfDay(zone)
+		);
 	}
 
 	private void updateDateAndTimePickers(ZonedDateTime dateTime) {
@@ -254,8 +265,12 @@ public class EventEditActivity extends AppCompatActivity implements OnTimeChange
 		// DON'T get the numbers directly from the time picker, but from the variables!
 		LocalDate date = dateTextViewController.getDate();
 		return date.atTime(selectedHour, selectedMinute)
-				.atZone(binding.timeZonePicker.getZoneId())
+				.atZone(getSelectedZone())
 				.toOffsetDateTime();
+	}
+
+	private ZoneId getSelectedZone() {
+		return binding.timeZonePicker.getZoneId();
 	}
 
 }

--- a/app/src/main/java/org/zephyrsoft/trackworktime/util/DateTimeUtil.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/util/DateTimeUtil.java
@@ -35,6 +35,7 @@ import java.util.Locale;
  */
 public class DateTimeUtil {
 	private static final DateTimeFormatter LOCALIZED_DATE = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM);
+	private static final DateTimeFormatter LOCALIZED_DATE_SHORT = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT);
 	private static final DateTimeFormatter LOCALIZED_TIME = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT);
 	private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 	private static final DateTimeFormatter HOUR_MINUTES = DateTimeFormatter.ofPattern("HH:mm");
@@ -107,6 +108,10 @@ public class DateTimeUtil {
 	 */
 	public static String formatLocalizedDate(LocalDate date) {
 		return date.format(LOCALIZED_DATE);
+	}
+
+	public static String formatLocalizedDateShort(TemporalAccessor temporal) {
+		return LOCALIZED_DATE_SHORT.format(temporal);
 	}
 
 	/**

--- a/app/src/main/java/org/zephyrsoft/trackworktime/util/DateTimeUtil.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/util/DateTimeUtil.java
@@ -17,6 +17,7 @@ package org.zephyrsoft.trackworktime.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.threeten.bp.DayOfWeek;
+import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.LocalTime;
@@ -226,6 +227,10 @@ public class DateTimeUtil {
 		} else {
 			return String.valueOf(number);
 		}
+	}
+
+	public static long dateToEpoch(ZonedDateTime accessor) {
+		return Instant.from(accessor).toEpochMilli();
 	}
 
 	public static boolean isDurationValid(String value) {

--- a/app/src/main/res/layout/event.xml
+++ b/app/src/main/res/layout/event.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:descendantFocusability="beforeDescendants"
     android:focusable="true"
     android:focusableInTouchMode="true"
@@ -78,18 +79,15 @@
                 android:text="@string/time"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <RelativeLayout
-                android:id="@+id/dateLayout"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
-
-                <DatePicker
-                    android:id="@+id/date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_centerHorizontal="true"
-                    android:calendarViewShown="false" />
-            </RelativeLayout>
+            <TextView
+                android:id="@+id/date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?editTextBackground"
+                android:focusable="false"
+                android:longClickable="false"
+                tools:text="12.4.2015"
+                />
 
             <TimePicker
                 android:id="@+id/time"


### PR DESCRIPTION
I've changed date selection on "edit event" screen to open date picker dialog on click, so it doesn't require scrolling.

I intend to do same for time picker.

#157 

![image](https://user-images.githubusercontent.com/5972966/135729035-9488a5ce-3056-4a71-8a74-eb87aa799ee6.png)
![image](https://user-images.githubusercontent.com/5972966/135729037-23efe274-e296-43cd-a5a5-5558e511ce69.png)
