### PR TITLE
Reports: Added grouping by task and hint

### DIFF
--- a/app/src/main/java/org/zephyrsoft/trackworktime/ReportsActivity.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/ReportsActivity.java
@@ -42,6 +42,7 @@ import org.zephyrsoft.trackworktime.model.Report;
 import org.zephyrsoft.trackworktime.model.Target;
 import org.zephyrsoft.trackworktime.model.TargetWrapper;
 import org.zephyrsoft.trackworktime.model.Task;
+import org.zephyrsoft.trackworktime.report.TaskAndHint;
 import org.zephyrsoft.trackworktime.model.TimeSum;
 import org.zephyrsoft.trackworktime.model.TypeEnum;
 import org.zephyrsoft.trackworktime.model.Unit;
@@ -153,14 +154,26 @@ public class ReportsActivity extends AppCompatActivity {
 			case R.id.groupingByTask:
 				report = createReportForTimesByTask();
 				break;
+			case R.id.groupingByTaskAndHint:
+				report = createReportForTimesByTaskAndHint();
+				break;
 			case R.id.groupingByTaskPerDay:
 				report = createReportForTimesByTaskPerDay();
+				break;
+			case R.id.groupingByTaskAndHintPerDay:
+				report = createReportForTimesByTaskAndHintPerDay();
 				break;
 			case R.id.groupingByTaskPerWeek:
 				report = createReportForTimesByTaskPerWeek();
 				break;
+			case R.id.groupingByTaskAndHintPerWeek:
+				report = createReportForTimesByTaskAndHintPerWeek();
+				break;
 			case R.id.groupingByTaskPerMonth:
 				report = createReportForTimesByTaskPerMonth();
+				break;
+			case R.id.groupingByTaskAndHintPerMonth:
+				report = createReportForTimesByTaskAndHintPerMonth();
 				break;
 			case R.id.targetGroupingNone:
 				report = createReportForAllTargets();
@@ -214,14 +227,26 @@ public class ReportsActivity extends AppCompatActivity {
 			case R.id.groupingByTask:
 				exportTimesByTask();
 				break;
+			case R.id.groupingByTaskAndHint:
+				exportTimesByTaskAndHint();
+				break;
 			case R.id.groupingByTaskPerDay:
 				exportTimesByTaskPerDay();
+				break;
+			case R.id.groupingByTaskAndHintPerDay:
+				exportTimesByTaskAndHintPerDay();
 				break;
 			case R.id.groupingByTaskPerWeek:
 				exportTimesByTaskPerWeek();
 				break;
+			case R.id.groupingByTaskAndHintPerWeek:
+				exportTimesByTaskAndHintPerWeek();
+				break;
 			case R.id.groupingByTaskPerMonth:
 				exportTimesByTaskPerMonth();
+				break;
+			case R.id.groupingByTaskAndHintPerMonth:
+				exportTimesByTaskAndHintPerMonth();
 				break;
 			case R.id.targetGroupingNone:
 				exportAllTargets();
@@ -310,6 +335,43 @@ public class ReportsActivity extends AppCompatActivity {
 		return new Report(reportName, report);
 	}
 
+	private void exportTimesByTaskAndHint() {
+		Report report = createReportForTimesByTaskAndHint();
+		if (report == null) {
+			return;
+		}
+
+		String name = report.getName();
+		String data = report.getData();
+		boolean success = saveAndSendReport(name,
+				"sums-" + name.replaceAll(" ", "-"),
+				data);
+
+		if (success) {
+			// close this dialog
+			finish();
+		}
+	}
+
+	private Report createReportForTimesByTaskAndHint() {
+		Range selectedRange = getSelectedRange();
+		Unit selectedUnit = getSelectedUnit();
+
+		ZonedDateTime[] beginAndEnd = timeCalculator.calculateBeginAndEnd(selectedRange, selectedUnit);
+		List<Event> events = dao.getEvents(beginAndEnd[0].toInstant(), beginAndEnd[1].toInstant());
+		truncateEventsToMinute(events);
+		Map<TaskAndHint, TimeSum> sums = timeCalculator.calculateSumsPerTaskAndHint(beginAndEnd[0].toOffsetDateTime(), beginAndEnd[1].toOffsetDateTime(), events);
+
+		String report = csvGenerator.createSumsCsvWithHints(sums);
+		String reportName = describeTimeRange(beginAndEnd);
+		if (report == null) {
+			logAndShowError(reportName);
+			return null;
+		}
+
+		return new Report(reportName, report);
+	}
+
 	private void exportTimesByTaskPerDay() {
 		Report report = createReportForTimesByTaskPerDay();
 		if (report == null) {
@@ -338,6 +400,43 @@ public class ReportsActivity extends AppCompatActivity {
 		Map<ZonedDateTime, Map<Task, TimeSum>> sumsPerRange = calculateSumsPerRange(rangeBeginnings, beginAndEnd[1]);
 
 		String report = csvGenerator.createSumsPerDayCsv(sumsPerRange);
+		String reportName = describeTimeRange(beginAndEnd);
+		if (report == null) {
+			logAndShowError(reportName);
+			return null;
+		}
+
+		return new Report(reportName, report);
+	}
+
+	private void exportTimesByTaskAndHintPerDay() {
+		Report report = createReportForTimesByTaskAndHintPerDay();
+		if (report == null) {
+			return;
+		}
+
+		String name = report.getName();
+		String data = report.getData();
+		boolean success = saveAndSendReport(name,
+				"sums-per-day-" + name.replaceAll(" ", "-"),
+				data);
+
+		if (success) {
+			// close this dialog
+			finish();
+		}
+	}
+
+	private Report createReportForTimesByTaskAndHintPerDay() {
+		Range selectedRange = getSelectedRange();
+		Unit selectedUnit = getSelectedUnit();
+
+		ZonedDateTime[] beginAndEnd = timeCalculator.calculateBeginAndEnd(selectedRange, selectedUnit);
+		List<ZonedDateTime> rangeBeginnings = timeCalculator.calculateRangeBeginnings(Unit.DAY, beginAndEnd[0],
+				beginAndEnd[1]);
+		Map<ZonedDateTime, Map<TaskAndHint, TimeSum>> sumsPerRange = calculateSumsWithHintsPerRange(rangeBeginnings, beginAndEnd[1]);
+
+		String report = csvGenerator.createSumsWithHintsPerDayCsv(sumsPerRange);
 		String reportName = describeTimeRange(beginAndEnd);
 		if (report == null) {
 			logAndShowError(reportName);
@@ -386,6 +485,46 @@ public class ReportsActivity extends AppCompatActivity {
 		return new Report(reportName, report);
 	}
 
+	private void exportTimesByTaskAndHintPerWeek() {
+		Report report = createReportForTimesByTaskAndHintPerWeek();
+		if (report == null) {
+			return;
+		}
+
+		String name = report.getName();
+		String data = report.getData();
+		boolean success = saveAndSendReport(name,
+				"sums-per-week-" + name.replaceAll(" ", "-"),
+				data);
+
+		if (success) {
+			// close this dialog
+			finish();
+		}
+	}
+
+	private Report createReportForTimesByTaskAndHintPerWeek() {
+		Range selectedRange = getSelectedRange();
+		Unit selectedUnit = getSelectedUnit();
+
+		ZonedDateTime[] beginAndEnd = timeCalculator.calculateBeginAndEnd(selectedRange, selectedUnit);
+		List<ZonedDateTime> rangeBeginnings = timeCalculator.calculateRangeBeginnings(Unit.WEEK, beginAndEnd[0],
+				beginAndEnd[1]);
+		Map<ZonedDateTime, Map<TaskAndHint, TimeSum>> sumsPerRange = calculateSumsWithHintsPerRange(rangeBeginnings, beginAndEnd[1]);
+
+		String report = csvGenerator.createSumsWithHintsPerWeeksCsv(sumsPerRange,
+				new String[] { "week", "task", "text", "spent" },
+				taskAndHint -> taskAndHint.getTask().getName() + " (ID=" + taskAndHint.getTask().getId() + ")",
+				taskAndHint -> taskAndHint.getText());
+		String reportName = describeTimeRange(beginAndEnd);
+		if (report == null) {
+			logAndShowError(reportName);
+			return null;
+		}
+
+		return new Report(reportName, report);
+	}
+
 	private void exportTimesByTaskPerMonth() {
 		Report report = createReportForTimesByTaskPerMonth();
 		if (report == null) {
@@ -416,6 +555,46 @@ public class ReportsActivity extends AppCompatActivity {
 		String report = csvGenerator.createSumsPerMonthCsv(sumsPerRange,
 			new String[] { "month", "task", "spent" },
 			task -> task.getName() + " (ID=" + task.getId() + ")");
+		String reportName = describeTimeRange(beginAndEnd);
+		if (report == null) {
+			logAndShowError(reportName);
+			return null;
+		}
+
+		return new Report(reportName, report);
+	}
+
+	private void exportTimesByTaskAndHintPerMonth() {
+		Report report = createReportForTimesByTaskAndHintPerMonth();
+		if (report == null) {
+			return;
+		}
+
+		String name = report.getName();
+		String data = report.getData();
+		boolean success = saveAndSendReport(name,
+				"sums-per-month-" + name.replaceAll(" ", "-"),
+				data);
+
+		if (success) {
+			// close this dialog
+			finish();
+		}
+	}
+
+	private Report createReportForTimesByTaskAndHintPerMonth() {
+		Range selectedRange = getSelectedRange();
+		Unit selectedUnit = getSelectedUnit();
+
+		ZonedDateTime[] beginAndEnd = timeCalculator.calculateBeginAndEnd(selectedRange, selectedUnit);
+		List<ZonedDateTime> rangeBeginnings = timeCalculator.calculateRangeBeginnings(Unit.MONTH, beginAndEnd[0],
+				beginAndEnd[1]);
+		Map<ZonedDateTime, Map<TaskAndHint, TimeSum>> sumsPerRange = calculateSumsWithHintsPerRange(rangeBeginnings, beginAndEnd[1]);
+
+		String report = csvGenerator.createSumsWithHintsPerMonthCsv(sumsPerRange,
+				new String[] { "month", "task", "text", "spent" },
+				taskAndHint -> taskAndHint.getTask().getName() + " (ID=" + taskAndHint.getTask().getId() + ")",
+				taskAndHint -> taskAndHint.getText());
 		String reportName = describeTimeRange(beginAndEnd);
 		if (report == null) {
 			logAndShowError(reportName);
@@ -550,6 +729,27 @@ public class ReportsActivity extends AppCompatActivity {
 			}
 			truncateEventsToMinute(events);
 			Map<Task, TimeSum> sums = timeCalculator.calculateSums(rangeStart.toOffsetDateTime(), rangeEnd.toOffsetDateTime(), events);
+			sumsPerRange.put(rangeStart, sums);
+		}
+		return sumsPerRange;
+	}
+
+	private Map<ZonedDateTime, Map<TaskAndHint, TimeSum>> calculateSumsWithHintsPerRange(List<ZonedDateTime> rangeBeginnings, ZonedDateTime end) {
+		Map<ZonedDateTime, Map<TaskAndHint, TimeSum>> sumsPerRange = new HashMap<>();
+
+		for (int i = 0; i < rangeBeginnings.size(); i++) {
+			ZonedDateTime rangeStart = rangeBeginnings.get(i);
+			ZonedDateTime rangeEnd = (i >= rangeBeginnings.size() - 1 ? end : rangeBeginnings.get(i + 1));
+			List<Event> events = dao.getEvents(rangeStart.toInstant(), rangeEnd.toInstant());
+			ZonedDateTime now = ZonedDateTime.now();
+			if (rangeStart.isBefore(now) && rangeEnd.isAfter(now)
+					&& !events.isEmpty()
+					&& events.get(events.size() - 1).getTypeEnum() == TypeEnum.CLOCK_IN
+					&& events.get(events.size() - 1).getDateTime().isBefore(now.toOffsetDateTime())) {
+				events.add(new Event(null, null, TypeEnum.CLOCK_OUT_NOW.getValue(), now.toOffsetDateTime(), null));
+			}
+			truncateEventsToMinute(events);
+			Map<TaskAndHint, TimeSum> sums = timeCalculator.calculateSumsPerTaskAndHint(rangeStart.toOffsetDateTime(), rangeEnd.toOffsetDateTime(), events);
 			sumsPerRange.put(rangeStart, sums);
 		}
 		return sumsPerRange;

--- a/app/src/main/java/org/zephyrsoft/trackworktime/report/TaskAndHint.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/report/TaskAndHint.java
@@ -1,0 +1,85 @@
+package org.zephyrsoft.trackworktime.report;
+
+import org.zephyrsoft.trackworktime.model.Base;
+import org.zephyrsoft.trackworktime.model.Task;
+
+/**
+ * Comparable class that holds a task and the hint/text for a event
+ **/
+public class TaskAndHint extends Base implements Comparable<TaskAndHint> {
+
+    private String text;
+    private Task task;
+
+    public TaskAndHint() {
+        // do nothing
+    }
+
+    public TaskAndHint(String text, Task task) {
+        this.text = text;
+        this.task = task;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Task getTask() {
+        return this.task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    @Override
+    public int compareTo(TaskAndHint another) {
+        return compare(getTask(), another.getTask(), compare(getText(), another.getText(), 0));
+    }
+
+    @Override
+    public String toString() {
+        return task.toString() + " " + (this.text == null ? "" : "'" + this.text + "'");
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((task != null) ? 0 : task.hashCode());
+        result = prime * result + ((text != null) ? 0 : text.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        TaskAndHint other = (TaskAndHint) obj;
+        if (task == null) {
+            if (other.getTask() == null) {
+                if (text == null) {
+                    return other.getText() == null;
+                }
+                return text.equals(other.getText());
+            }
+            return false;
+        } else if (text == null) {
+            if (other.getText() == null) {
+                return task.equals(other.getTask());
+            }
+            return false;
+        } else {
+            return task.equals(other.getTask()) && text.equals(other.getText());
+        }
+    }
+}

--- a/app/src/main/java/org/zephyrsoft/trackworktime/report/TaskAndHint.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/report/TaskAndHint.java
@@ -1,3 +1,18 @@
+/*
+ * This file is part of TrackWorkTime (TWT).
+ *
+ * TWT is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License 3.0 as published by
+ * the Free Software Foundation.
+ *
+ * TWT is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License 3.0 for more details.
+ *
+ * You should have received a copy of the GNU General Public License 3.0
+ * along with TWT. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.zephyrsoft.trackworktime.report;
 
 import org.zephyrsoft.trackworktime.model.Base;

--- a/app/src/main/java/org/zephyrsoft/trackworktime/report/TimeSumsAndHintsHolder.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/report/TimeSumsAndHintsHolder.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of TrackWorkTime (TWT).
+ * 
+ * TWT is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License 3.0 as published by
+ * the Free Software Foundation.
+ * 
+ * TWT is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License 3.0 for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 3.0
+ * along with TWT. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.zephyrsoft.trackworktime.report;
+
+import androidx.annotation.NonNull;
+
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.zephyrsoft.trackworktime.model.TimeSum;
+
+/**
+ * Holds the data for reporting.
+ */
+public class TimeSumsAndHintsHolder implements Comparable<TimeSumsAndHintsHolder> {
+
+	private String month;
+	private String week;
+	private String day;
+	private String task;
+	private String text;
+	private TimeSum spent;
+
+	public TimeSumsAndHintsHolder(String month, String week, String day, String task, String text, TimeSum spent) {
+		this.month = month;
+		this.week = week;
+		this.day = day;
+		this.task = task;
+		this.text = text;
+		this.spent = spent;
+	}
+
+	public static @NonNull TimeSumsAndHintsHolder createForDay(String day, String task, String text, TimeSum spent) {
+		return new TimeSumsAndHintsHolder(null, null, day, task, text, spent);
+	}
+
+	public static @NonNull TimeSumsAndHintsHolder createForWeek(String week, String task, String text, TimeSum spent) {
+		return new TimeSumsAndHintsHolder(null, week, null, task, text, spent);
+	}
+
+	public static @NonNull TimeSumsAndHintsHolder createForMonth(String month, String task, String text, TimeSum spent) {
+		return new TimeSumsAndHintsHolder(month, null, null, task, text, spent);
+	}
+
+	public String getDay() {
+		return day;
+	}
+
+	public void setDay(String day) {
+		this.day = day;
+	}
+
+	public String getWeek() {
+		return week;
+	}
+
+	public void setWeek(String week) {
+		this.week = week;
+	}
+
+	public String getMonth() {
+		return month;
+	}
+
+	public void setMonth(String month) {
+		this.month = month;
+	}
+
+	public String getTask() {
+		return task;
+	}
+
+	public void setTask(String task) {
+		this.task = task;
+	}
+
+	public String getText() {
+		return this.text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public TimeSum getSpent() {
+		return spent;
+	}
+
+	public void setSpent(TimeSum spent) {
+		this.spent = spent;
+	}
+
+	@Override
+	public int compareTo(TimeSumsAndHintsHolder another) {
+		if (another == null) {
+			return 1;
+		}
+		return new CompareToBuilder()
+			.append(getMonth(), another.getMonth())
+			.append(getWeek(), another.getWeek())
+			.append(getDay(), another.getDay())
+			.append(getTask(), another.getTask())
+			.append(getText(), another.getText())
+			.toComparison();
+	}
+
+}

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
@@ -226,12 +226,6 @@ public class TimeCalculator {
 		}
 		// add new times to sum
 		long minutesWorked = ChronoUnit.MINUTES.between(from, to);
-		if (minutesWorked > Integer.MAX_VALUE - 60) {
-			// this is extremely unlikely, someone would have to work 4084 years without pause...
-			int correctedMinutesWorked = Integer.MAX_VALUE - 60;
-			Logger.warn("could not handle {} minutes, number is too high - taking {} instead",
-					minutesWorked, correctedMinutesWorked);
-		}
 		sumForTask.add(0, (int) minutesWorked);
 	}
 

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
@@ -225,8 +225,8 @@ public class TimeCalculator {
 			mapForCounting.put(taskAndHint, sumForTask);
 		}
 		// add new times to sum
-		long minutesWorked = ChronoUnit.MINUTES.between(from, to);
-		sumForTask.add(0, (int) minutesWorked);
+		int minutesWorked = (int) ChronoUnit.MINUTES.between(from, to);
+		sumForTask.add(0, minutesWorked);
 	}
 
 	public ZonedDateTime[] calculateBeginAndEnd(Range range, Unit unit) {

--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculator.java
@@ -27,6 +27,7 @@ import org.zephyrsoft.trackworktime.database.DAO;
 import org.zephyrsoft.trackworktime.model.Event;
 import org.zephyrsoft.trackworktime.model.Range;
 import org.zephyrsoft.trackworktime.model.Task;
+import org.zephyrsoft.trackworktime.report.TaskAndHint;
 import org.zephyrsoft.trackworktime.model.TimeSum;
 import org.zephyrsoft.trackworktime.model.Unit;
 import org.zephyrsoft.trackworktime.util.DateTimeUtil;
@@ -156,6 +157,48 @@ public class TimeCalculator {
 		return ret;
 	}
 
+	/**
+	 * Calculate the time sums per task and hint in a given time range.
+	 */
+	public Map<TaskAndHint, TimeSum> calculateSumsPerTaskAndHint(OffsetDateTime beginOfPeriod, OffsetDateTime endOfPeriod, List<Event> events) {
+		Map<TaskAndHint, TimeSum> ret = new HashMap<>();
+		if (events == null || events.isEmpty()) {
+			return ret;
+		}
+
+		OffsetDateTime timeOfFirstEvent = events.get(0).getDateTime();
+		Event lastEventBefore = dao.getLastEventBefore(timeOfFirstEvent);
+
+		OffsetDateTime clockedInSince = null;
+		TaskAndHint currentTaskAndHint = null;
+
+		if (TimerManager.isClockInEvent(lastEventBefore)) {
+			// clocked in since begin of period
+			clockedInSince = beginOfPeriod;
+			currentTaskAndHint = lastEventBefore.getTask() != null ? new TaskAndHint(lastEventBefore.getText(), dao.getTask(lastEventBefore.getTask())) : null;
+		}
+
+		for (Event event : events) {
+			OffsetDateTime eventTime = event.getDateTime();
+			if (clockedInSince != null) {
+				countTime(ret, currentTaskAndHint, clockedInSince, eventTime);
+			}
+			if (TimerManager.isClockInEvent(event)) {
+				clockedInSince = eventTime;
+				currentTaskAndHint = event.getTask() != null ? new TaskAndHint(event.getText(), dao.getTask(event.getTask())) : null;
+			} else {
+				clockedInSince = null;
+				currentTaskAndHint = null;
+			}
+		}
+
+		if (clockedInSince != null) {
+			countTime(ret, currentTaskAndHint, clockedInSince, endOfPeriod);
+		}
+
+		return ret;
+	}
+
 	private static void countTime(Map<Task, TimeSum> mapForCounting, Task task, OffsetDateTime from, OffsetDateTime to) {
 		// fetch sum up to now
 		TimeSum sumForTask = mapForCounting.get(task);
@@ -170,6 +213,24 @@ public class TimeCalculator {
 			int correctedMinutesWorked = Integer.MAX_VALUE - 60;
 			Logger.warn("could not handle {} minutes, number is too high - taking {} instead",
 				minutesWorked, correctedMinutesWorked);
+		}
+		sumForTask.add(0, (int) minutesWorked);
+	}
+
+	private static void countTime(Map<TaskAndHint, TimeSum> mapForCounting, TaskAndHint taskAndHint, OffsetDateTime from, OffsetDateTime to) {
+		// fetch sum up to now
+		TimeSum sumForTask = mapForCounting.get(taskAndHint);
+		if (sumForTask == null) {
+			sumForTask = new TimeSum();
+			mapForCounting.put(taskAndHint, sumForTask);
+		}
+		// add new times to sum
+		long minutesWorked = ChronoUnit.MINUTES.between(from, to);
+		if (minutesWorked > Integer.MAX_VALUE - 60) {
+			// this is extremely unlikely, someone would have to work 4084 years without pause...
+			int correctedMinutesWorked = Integer.MAX_VALUE - 60;
+			Logger.warn("could not handle {} minutes, number is too high - taking {} instead",
+					minutesWorked, correctedMinutesWorked);
 		}
 		sumForTask.add(0, (int) minutesWorked);
 	}

--- a/app/src/main/res/layout/reports.xml
+++ b/app/src/main/res/layout/reports.xml
@@ -113,10 +113,22 @@
                 android:text="@string/eventGroupingByTask" />
 
             <RadioButton
+                android:id="@+id/groupingByTaskAndHint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/eventGroupingByTaskAndHint" />
+
+            <RadioButton
                 android:id="@+id/groupingByTaskPerDay"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/eventGroupingByTaskPerDay"/>
+
+            <RadioButton
+                android:id="@+id/groupingByTaskAndHintPerDay"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/eventGroupingByTaskAndHintPerDay" />
 
             <RadioButton
                 android:id="@+id/groupingByTaskPerWeek"
@@ -125,10 +137,22 @@
                 android:text="@string/eventGroupingByTaskPerWeek"/>
 
             <RadioButton
+                android:id="@+id/groupingByTaskAndHintPerWeek"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/eventGroupingByTaskAndHintPerWeek" />
+
+            <RadioButton
                 android:id="@+id/groupingByTaskPerMonth"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/eventGroupingByTaskPerMonth"/>
+
+            <RadioButton
+                android:id="@+id/groupingByTaskAndHintPerMonth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/eventGroupingByTaskAndHintPerMonth" />
 
             <RadioButton
                 android:id="@+id/targetGroupingNone"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,9 +172,13 @@
     <string name="eventGrouping">Grouping</string>
     <string name="eventGroupingNone">Events: raw (all events)</string>
     <string name="eventGroupingByTask">Events: Times per Task</string>
+    <string name="eventGroupingByTaskAndHint">Events: Times per Task and Hint</string>
     <string name="eventGroupingByTaskPerDay">Events: times per task (daily)</string>
+    <string name="eventGroupingByTaskAndHintPerDay">Events: times per task and hint (daily)</string>
     <string name="eventGroupingByTaskPerWeek">Events: times per task (weekly)</string>
+    <string name="eventGroupingByTaskAndHintPerWeek">Events: times per task and hint (weekly)</string>
     <string name="eventGroupingByTaskPerMonth">Events: times per task (monthly)</string>
+    <string name="eventGroupingByTaskAndHintPerMonth">Events: times per task and hint (monthly)</string>
     <string name="targetGroupingNone">Targets: raw (all targets)</string>
     <string name="targetGroupingPerWeek">Targets: days per type/comment (weekly)</string>
     <string name="targetGroupingPerMonth">Targets: days per type/comment (monthly)</string>

--- a/app/src/test/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorTest.java
+++ b/app/src/test/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorTest.java
@@ -1,6 +1,7 @@
 package org.zephyrsoft.trackworktime.timer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
@@ -15,18 +16,31 @@ import org.junit.Test;
 import org.zephyrsoft.trackworktime.database.DAO;
 import org.zephyrsoft.trackworktime.model.Event;
 import org.zephyrsoft.trackworktime.model.Range;
+import org.zephyrsoft.trackworktime.model.Task;
+import org.zephyrsoft.trackworktime.model.TimeSum;
+import org.zephyrsoft.trackworktime.model.TypeEnum;
 import org.zephyrsoft.trackworktime.model.Unit;
+import org.zephyrsoft.trackworktime.report.TaskAndHint;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class TimeCalculatorTest {
 
     private final ZonedDateTime now = ZonedDateTime.now();
-    private final ZonedDateTime oneYearBack = now.minusYears(1);
+
+    private final Task task1 = new Task(0, "development", 1, 1, 0);
+    private final Task task2 = new Task(1, "review", 1, 2, 0);
+
+    private final String hint1 = "ticket-123";
+    private final String hint2 = "ticket-456";
+
+    private List<Event> events = new ArrayList<>();
 
     private TimeCalculator timeCalculator;
 
@@ -38,12 +52,31 @@ public class TimeCalculatorTest {
         doReturn(ZoneId.systemDefault()).when(timerManager).getHomeTimeZone();
 
         doReturn(List.of(
-            eventAt(oneYearBack),
+            eventAt(now.minusYears(1)),
             eventAt(now.minusMonths(1)),
             eventAt(now.minusWeeks(1)),
             eventAt(now.minusDays(1)),
             eventAt(now)
         )).when(dao).getAllEvents();
+
+        doReturn(task1).when(dao).getTask(task1.getId());
+        doReturn(task2).when(dao).getTask(task2.getId());
+
+        // Event list for 10 days
+        for(int i = 10; i > 5; i--) {
+            events.add(eventAt(now.minusDays(i).plusHours(1), task1, i % 2 == 0 ? hint1 : hint2));
+            events.add(eventAt(now.minusDays(i).plusHours(2), task1, i % 2 == 0 ? hint1 : ""));
+            events.add(eventAt(now.minusDays(i).plusHours(3), task1, i % 2 == 0 ? hint2 : hint1));
+            events.add(eventAt(now.minusDays(i).plusHours(4), task1, i % 2 == 0 ? "" : hint2));
+            events.add(clockOutEvent(now.minusDays(i).plusHours(5)));
+        }
+        for(int i = 5; i > 0; i--) {
+            events.add(eventAt(now.minusDays(i).plusHours(1), task2, i % 2 == 0 ? hint1 : hint2));
+            events.add(eventAt(now.minusDays(i).plusHours(2), task2, i % 2 == 0 ? hint1 : ""));
+            events.add(eventAt(now.minusDays(i).plusHours(3), task2, i % 2 == 0 ? hint2 : hint1));
+            events.add(eventAt(now.minusDays(i).plusHours(4), task2, i % 2 == 0 ? "" : hint2));
+            events.add(clockOutEvent(now.minusDays(i).plusHours(5)));
+        }
 
         timeCalculator = new TimeCalculator(dao, timerManager);
     }
@@ -89,10 +122,57 @@ public class TimeCalculatorTest {
             Range.LAST,
             Unit.YEAR);
 
-        assertRange(oneYearBack.with(LocalTime.MIN),
+        assertRange(now.minusYears(1).with(LocalTime.MIN),
             now.with(LocalTime.MAX),
             Range.ALL_DATA,
             null);
+    }
+
+    @Test
+    public void calculateSumsPerTaskAndHint() {
+        assertSumsPerTaskAndHintMap(Map.of(),
+                now.minusDays(10), now, null);
+        assertSumsPerTaskAndHintMap(Map.of(),
+                now.minusDays(10), now, List.of());
+
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task2, hint2), timeSum(2),
+                        taskAndHint(task2, ""), timeSum(1),
+                        taskAndHint(task2, hint1), timeSum(1)),
+                now.minusDays(1), now, events);
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task1, hint1), timeSum(2),
+                        taskAndHint(task1, hint2), timeSum(1),
+                        taskAndHint(task1, ""), timeSum(1)),
+                now.minusDays(10), now.minusDays(9), events);
+
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task2, hint2), timeSum(8),
+                        taskAndHint(task2, ""), timeSum(5),
+                        taskAndHint(task2, hint1), timeSum(7)),
+                now.minusDays(5), now, events);
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task1, hint1), timeSum(8),
+                        taskAndHint(task1, hint2), timeSum(7),
+                        taskAndHint(task1, ""), timeSum(5)),
+                now.minusDays(10), now.minusDays(5), events);
+
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task1, hint2), timeSum(3),
+                        taskAndHint(task1, ""), timeSum(2),
+                        taskAndHint(task1, hint1), timeSum(3),
+                        taskAndHint(task2, hint2), timeSum(3),
+                        taskAndHint(task2, ""), timeSum(2),
+                        taskAndHint(task2, hint1), timeSum(3)),
+                now.minusDays(7), now.minusDays(3), events);
+        assertSumsPerTaskAndHintMap(Map.of(
+                        taskAndHint(task1, hint1), timeSum(8),
+                        taskAndHint(task1, hint2), timeSum(7),
+                        taskAndHint(task1, ""), timeSum(5),
+                        taskAndHint(task2, hint2), timeSum(8),
+                        taskAndHint(task2, ""), timeSum(5),
+                        taskAndHint(task2, hint1), timeSum(7)),
+                now.minusDays(10), now, events);
     }
 
     private void assertRange(ZonedDateTime expectedStart, ZonedDateTime expectedEnd,
@@ -104,9 +184,64 @@ public class TimeCalculatorTest {
             expectedEnd, beginAndEnd[1]);
     }
 
+    private void assertSumsPerTaskAndHintMap(Map<TaskAndHint, TimeSum> expected, ZonedDateTime begin, ZonedDateTime end, List<Event> events) {
+        Map<TaskAndHint, TimeSum> actual = timeCalculator.calculateSumsPerTaskAndHint(
+                begin.toOffsetDateTime(),
+                begin.toOffsetDateTime(),
+                eventsInRange(events, begin, end));
+        assertEquals(expected.size(), expected.size());
+        for(Map.Entry<TaskAndHint, TimeSum> entry : expected.entrySet()) {
+            assertTrue(expected.keySet().contains(entry.getKey()));
+            assertEquals(actual.get(entry.getKey()).getAsMinutes(), entry.getValue().getAsMinutes());
+        }
+    }
+
     private static Event eventAt(ZonedDateTime offsetDateTime) {
         Event e = new Event();
         e.setDateTime(offsetDateTime.toOffsetDateTime());
         return e;
+    }
+
+    private static Event eventAt(ZonedDateTime offsetDateTime, Task task, String hint) {
+        Event e = new Event();
+        e.setDateTime(offsetDateTime.toOffsetDateTime());
+        e.setType(TypeEnum.CLOCK_IN.getValue());
+        e.setTask(task.getId());
+        e.setText(hint);
+        return e;
+    }
+
+    private static List<Event> eventsInRange(List<Event> events, ZonedDateTime from, ZonedDateTime to) {
+        List<Event> res = new ArrayList<>();
+        if (events != null && !events.isEmpty()) {
+            for (Event e : events) {
+                if (from.toOffsetDateTime().isBefore(e.getTime())
+                        && to.toOffsetDateTime().isAfter(e.getTime())) {
+                    res.add(e);
+                }
+            }
+        }
+        return res;
+    }
+
+    private static Event clockOutEvent(ZonedDateTime time) {
+        Event e = new Event();
+        e.setType(TypeEnum.CLOCK_OUT.getValue());
+        e.setDateTime(time.toOffsetDateTime());
+        return e;
+    }
+
+    private static TaskAndHint taskAndHint(Task task, String hint) {
+        return  new TaskAndHint(hint, task);
+    }
+
+    private static TimeSum timeSum(int hours) {
+        return timeSum(hours, 0);
+    }
+
+    private static TimeSum timeSum(int hours, int minutes) {
+        TimeSum t = new TimeSum();
+        t.set(hours, minutes);
+        return t;
     }
 }


### PR DESCRIPTION
Hello TWT Community,

At work, we recently got new time tracking rules, this way I found your app. I am working tickets within a ticketing system, and have different activities to do for each ticket. I use the tasks for each of these activities, and put the ticket numbers in the hint field (some tickets may be quick to complete, so always adding/removing tasks for all of them was not really an option for me). This is the reason, I thought it would be handy, to have an option to export reports with time sums not only grouped by task alone, but by the combination of the task and the hint of an event. This is my attempt to implement this.

There is a new type `TaskAndHint`, which is used to hold the task as well as the hint of an event as a Map Key. This then allows using the new time calculation methods, which are pretty similar to the ones of the "times by task" options, respectively. On top of that, there are new radio buttons for these options, and some additions around the CSV generator, to export this new format. It still works with empty hints, which will be handled as empty strings in this case - so everything of the same task without a hint will also be grouped together. I added all four options: the general one, daily, weekly and monthly, for it to be similar to the existing  "times per task *" grouping options (I am interested in the daily one mostly). I at least tested it with some test inputs within the android studio emulator, but not on a real device yet.

I tried to keep in-sync with the existing code style, but also I do not have any experience with app-development at all. Let me know what you think of the idea and implementation, or if there is anything I can do better.

Thanks for your work on the app and keeping FOSS apps alive :smile: 


Merry Christmas & happy holidays :santa: 