### PR TITLE
Attempt to Resolve Issue #291

### DIFF
--- a/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorV2.java
+++ b/app/src/main/java/org/zephyrsoft/trackworktime/timer/TimeCalculatorV2.java
@@ -245,7 +245,8 @@ public class TimeCalculatorV2 {
 				// clocked in before the begin of day or no clock-in event this day
 			}
 
-			if (clockedInSince != null) {
+			if (clockedInSince != null &&
+					LocalDateTime.now().isAfter(clockedInSince.toLocalDateTime())) {
 				// still clocked-in at the end of the day
 				timeOut = currentDate.atTime(LocalTime.MAX).atZone(zoneId).toOffsetDateTime();
 
@@ -259,7 +260,8 @@ public class TimeCalculatorV2 {
 			// update last event
 			lastEventBeforeDay = events.get(events.size() - 1);
 
-		} else if (TimerManager.isClockInEvent(lastEventBeforeDay)) {
+		} else if (TimerManager.isClockInEvent(lastEventBeforeDay) &&
+				LocalDateTime.now().isAfter(lastEventBeforeDay.getTime().toLocalDateTime())) {
 			// although there are no events on this day, the user is clocked in all day long -
 			// else there would be a CLOCK_OUT_NOW event!
 			timeIn = currentDate.atTime(LocalTime.MIN).atZone(zoneId).toOffsetDateTime();


### PR DESCRIPTION
To try and and fix issue #291 I added 2 additional checks in the TimeCalculatorV2 Class. Those are supposed to check if the current Time is after the clockInEvent which would affect the workedTime. If there is no clockOutEvent and the clockInEvent is in the Future there is 0 workedTime calculated.